### PR TITLE
Implement password hashing for users

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const path = require('path');
 const db = require('./database/database'); // Importa a configuração do banco e o objeto db
-// const bcrypt = require('bcryptjs'); // Descomente quando for implementar hash de senha
+const bcrypt = require('bcryptjs'); // Biblioteca para hash de senha
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -487,9 +487,8 @@ app.post('/api/usuarios', async (req, res) => {
     }
 
     // TODO: Validação de existência dos IDs de chave estrangeira no banco (id_tipo_usuario, id_nivel_acesso, id_cad_escola se fornecido)
-    // const sal = await bcrypt.genSalt(10); // Para hash de senha
-    // const senhaHash = await bcrypt.hash(senhaOriginal, sal); // Para hash de senha
-    const senhaHash = senhaOriginal; // SUBSTITUIR PELO HASH REAL
+    const sal = await bcrypt.genSalt(10);
+    const senhaHash = await bcrypt.hash(senhaOriginal, sal);
 
     const sql = `INSERT INTO cadastro_usuarios 
                  (nome_completo, email, matricula, data_admissao, id_cad_escola, id_tipo_usuario, id_nivel_acesso, senha, status_usuario)
@@ -590,9 +589,8 @@ app.put('/api/usuarios/:id', async (req, res) => {
     let senhaFoiAlterada = false;
 
     if (senha && senha.trim() !== "") {
-        // const sal = await bcrypt.genSalt(10);
-        // const senhaHash = await bcrypt.hash(senha, sal);
-        const senhaHash = senha; // REMOVER QUANDO USAR BCRYPT
+        const sal = await bcrypt.genSalt(10);
+        const senhaHash = await bcrypt.hash(senha, sal);
         sqlUpdate = `UPDATE cadastro_usuarios SET 
                      nome_completo = ?, email = ?, matricula = ?, data_admissao = ?, 
                      id_cad_escola = ?, id_tipo_usuario = ?, id_nivel_acesso = ?, 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^3.0.2",
         "express": "^5.1.0",
         "sqlite3": "^5.1.7"
       }
@@ -174,6 +175,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bindings": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "bcryptjs": "^3.0.2",
     "express": "^5.1.0",
     "sqlite3": "^5.1.7"
   }


### PR DESCRIPTION
## Summary
- add bcryptjs dependency
- hash user passwords on create/update

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a32ce350c8324a3082917ded1a08f